### PR TITLE
build: 更新 React 相关依赖至 v19.0.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,7 +103,7 @@ importers:
         version: 2.55.0
       '@xstate/react':
         specifier: ^6.0.0
-        version: 6.0.0(@types/react@18.3.24)(react@18.3.1)(xstate@5.20.2)
+        version: 6.0.0(@types/react@19.0.0)(react@19.0.0)(xstate@5.20.2)
       ai:
         specifier: latest
         version: 5.0.13(zod@3.25.67)
@@ -172,7 +172,7 @@ importers:
         version: 1.0.7(tailwindcss@3.4.17)
       vaul:
         specifier: ^0.9.6
-        version: 0.9.9(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 0.9.9(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       xstate:
         specifier: ^5.20.2
         version: 5.20.2
@@ -4787,11 +4787,11 @@ snapshots:
 
   '@xmldom/xmldom@0.8.10': {}
 
-  '@xstate/react@6.0.0(@types/react@18.3.24)(react@18.3.1)(xstate@5.20.2)':
+  '@xstate/react@6.0.0(@types/react@19.0.0)(react@19.0.0)(xstate@5.20.2)':
     dependencies:
-      react: 18.3.1
-      use-isomorphic-layout-effect: 1.2.1(@types/react@18.3.24)(react@18.3.1)
-      use-sync-external-store: 1.5.0(react@18.3.1)
+      react: 19.0.0
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.0.0)(react@19.0.0)
+      use-sync-external-store: 1.5.0(react@19.0.0)
     optionalDependencies:
       xstate: 5.20.2
     transitivePeerDependencies:
@@ -6799,13 +6799,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.0.0
 
-  use-isomorphic-layout-effect@1.2.1(@types/react@18.3.24)(react@18.3.1):
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.0.0)(react@19.0.0):
     dependencies:
-      react: 18.3.1
+      react: 19.0.0
     optionalDependencies:
-      '@types/react': 18.3.24
+      '@types/react': 19.0.0
 
-  use-sidecar@1.1.3(@types/react@18.3.24)(react@18.3.1):
+  use-sidecar@1.1.3(@types/react@19.0.0)(react@19.0.0):
     dependencies:
       detect-node-es: 1.1.0
       react: 19.0.0


### PR DESCRIPTION
更新 @xstate/react 和 vaul 等包的依赖项，将 React 从 v18.3.1 升级到 v19.0.0，同时更新对应的 @types/react 类型定义